### PR TITLE
don't set up stuff via debops.auth that's not required

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,8 @@
 
 dependencies:
 
-  - role: debops.auth
+  - { role: debops.auth, auth_system_groups: [ sftponly ], auth_admin_accounts: [], auth_wheel_group: False }
+
 
 galaxy_info:
   author: 'Maciej Delmanowski'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,5 @@
 ---
 
-dependencies:
-
-  - { role: debops.auth, auth_system_groups: [ sftponly ], auth_admin_accounts: [], auth_wheel_group: False }
-
-
 galaxy_info:
   author: 'Maciej Delmanowski'
   description: 'Manage user accounts restricted to SFTP access'


### PR DESCRIPTION
Hello again Maciej,

this pull request has the same goal as the one on debops.auth: the idea is to only set up stuff on the target host, that is really required and leave everything else alone.

This pull request requires the change from commit #342362d in debops.auth to work properly.